### PR TITLE
feat: allow configuring camera for gui

### DIFF
--- a/fakecam/fakecam/ui/mainwindow.py
+++ b/fakecam/fakecam/ui/mainwindow.py
@@ -48,6 +48,11 @@ class MainWindow:
 
             if config.has_section("main"):
                 try:
+                    self.camera = config.get("main", "camera")
+                except configparser.NoOptionError:
+                    pass
+
+                try:
                     self.use_hologram = config.getboolean("main", "hologram")
                     builder.get_object("hologram_toggle").set_active(self.use_hologram)
                 except configparser.NoOptionError:


### PR DESCRIPTION
This allows users to add the following to `config.ini`:

```
camera = "/dev/videoX"
```

Since the webcam may not always be at `/dev/video0`.