### PR TITLE
Added customizable output device to CLI

### DIFF
--- a/src/fakecam/capture.py
+++ b/src/fakecam/capture.py
@@ -98,13 +98,13 @@ def get_frame(cap: object, scaler: BodypixScaler, ones, dilation, background: ob
     return frame
 
 
-def start(command_queue: "Queue[CommandQueueDict]" = None, return_queue: "Queue[bool]" = None, camera: str = "/dev/video0", background: str = None,
+def start(command_queue: "Queue[CommandQueueDict]" = None, return_queue: "Queue[bool]" = None, camera_input: str = "/dev/video0", camera_output: str = "/dev/video20", background: str = None,
           use_hologram: bool = False, use_mirror: bool = False, resolution: Tuple[int,int] = None):
     # setup access to the *real* webcam
-    print("Starting capture using device: {camera}".format(camera=camera))
-    cap = cv2.VideoCapture(camera, cv2.CAP_V4L2)
+    print("Starting capture using device: {camera}".format(camera=camera_input))
+    cap = cv2.VideoCapture(camera_input, cv2.CAP_V4L2)
     if not cap.isOpened():
-        print("Failed to open {camera}".format(camera=camera))
+        print("Failed to open {camera}".format(camera=camera_input))
         return
 
     orig_width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
@@ -134,7 +134,7 @@ def start(command_queue: "Queue[CommandQueueDict]" = None, return_queue: "Queue[
     #         break
 
     # setup the fake camera
-    fake = FakeWebcam("/dev/video20", width, height)
+    fake = FakeWebcam(camera_output, width, height)
 
     # load the virtual background
     background_scaled = None

--- a/src/fakecam/cli.py
+++ b/src/fakecam/cli.py
@@ -15,11 +15,12 @@ def main():
     background = None
     use_hologram = False
     use_mirror = False
-    camera = "/dev/video0"
+    camera_input = "/dev/video0"
+    camera_output = "/dev/video20"
     resolution = None
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "hi:r:b:mg", ["input=", "resolution=", "background=", "mirror", "hologram"])
+        opts, args = getopt.getopt(sys.argv[1:], "hi:o:r:b:mg", ["input=", "output=", "resolution=", "background=", "mirror", "hologram"])
     except getopt.GetoptError:
         usage()
         sys.exit(2)
@@ -29,7 +30,9 @@ def main():
             usage()
             sys.exit()
         elif opt in ("-i", "--input"):
-            camera = arg
+            camera_input = arg
+        elif opt in ("-o", "--output"):
+            camera_output = arg
         elif opt in ("-r", "--resolution"):
             res = str.split(arg, 'x', 2)
             resolution = (int(res[0]), int(res[1]))
@@ -40,11 +43,11 @@ def main():
         elif opt in ("-g", "--hologram"):
             use_hologram = True
 
-    if not os.access(camera, os.R_OK):
+    if not os.access(camera_input, os.R_OK):
         print(lang.CONNECT_INTERFACE + "\n\nIf you have multiple camera devices in /dev/video* then you may specify "
                                        "the correct device with the '-i' or '--input' parameter.\n")
 
-    if not os.access("/dev/video20", os.W_OK):
+    if not os.access(camera_output, os.W_OK):
         print(lang.INSTRUCTIONS)
         sys.exit(3)
 
@@ -65,7 +68,8 @@ def main():
         background = None
 
     args = {
-        "camera": camera,
+        "camera_input": camera_input,
+        "camera_output": camera_output,
         "background": background,
         "use_hologram": use_hologram,
         "use_mirror": use_mirror,

--- a/src/fakecam/lang.py
+++ b/src/fakecam/lang.py
@@ -27,11 +27,13 @@ CONNECT_INTERFACE = "Your camera is not accessible. You need to manually run the
 
 USAGE = """
 USAGE:
-    fakecam [--input=<camera-device>] [--resolution=<width>x<height>] [--background=<background-file>] [--hologram]
+    fakecam [--input=<camera-device>] [--output=<dummy-device>] [--resolution=<width>x<height>] [--background=<background-file>] [--hologram]
 
 PARAMETERS:
   --help:       display this help document.
   --input:      specify the camera device to use. The default is /dev/video0.
+  --output:     specify the dummy device for output. The default is
+                /dev/video20.
   --resolution: override your camera's default resolution. Must be width and
                 height as numbers separated by an 'x', e.g. '640x480'. May not
                 work reliably.


### PR DESCRIPTION
The hardcoded `/dev/video20` for output can sometimes be a bit inconvenient, so this PR adds a flag `--output` to the CLI which accepts the path to the device to output the stream to.
I've thought about implementing it for the GUI as well, but I use fakecam primarily from the CLI and don't have Glade installed so I'll leave that up to someone else.