### PR TITLE
snapcore/action-build@v1.1.3

### DIFF
--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: snapcore/action-build@v1
+    - uses: snapcore/action-build@v1.1.3
       id: build
     - uses: diddlesnaps/snapcraft-review-tools-action@v1
       with:


### PR DESCRIPTION
Fix for RuntimeError: ERROR: base 'core18' was last supported on Snapcraft 7 available on the '7.x' channel.